### PR TITLE
Fix getItemsAtRange

### DIFF
--- a/packages/slate-edit-list/src/utils/getItemsAtRange.ts
+++ b/packages/slate-edit-list/src/utils/getItemsAtRange.ts
@@ -40,7 +40,7 @@ const getItemsAtRange = (opts: Options) => (
     const startPath = ancestor.getPath(startBlock.key);
     const endPath = ancestor.getPath(endBlock.key);
 
-    return ancestor.nodes.slice(startPath[0], endPath[0] + 1) as List<Block>;
+    return ancestor.nodes.slice(startPath.first(), endPath.first() + 1) as List<Block>;
   } else if (ancestor.type === opts.typeItem) {
     // The ancestor is the highest list item that covers the range
     return List([ancestor]);


### PR DESCRIPTION
Starting from version 0.35 Paths are an instance of List instead of Array

https://github.com/ianstormtaylor/slate/blob/eb79c3dbff27c8f39113a9f747356a9a1c78c3a8/packages/slate/Changelog.md#0350--july-27-2018